### PR TITLE
fix(docker): correct build output path from dist to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn global add pnpm &&\
 FROM httpd:alpine3.21
 WORKDIR /usr/local/apache2/htdocs
 EXPOSE 8888
-COPY --chown=www-data:www-data --from=builder /app/dist /usr/local/apache2/htdocs
+COPY --chown=www-data:www-data --from=builder /app/build /usr/local/apache2/htdocs
 RUN apk add libcap && chown -hR www-data:www-data /usr/local/apache2/ && \
   setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd
 USER www-data


### PR DESCRIPTION
vite.config.ts sets outDir to 'build', but Dockerfile was copying from '/app/dist' which did not exist, causing CI to fail.